### PR TITLE
fix(sys): build riscv32imafc with the hard-float ABI rustc uses

### DIFF
--- a/mbedtls-rs-sys/CHANGELOG.md
+++ b/mbedtls-rs-sys/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+* Build `riscv32imafc-*` with the hard-float `ilp32f` ABI rustc uses, fixing a link failure on ESP32-P4 / ESP32-S31
+
 ## [0.2.0] - 2026-08-20
 * (Breaking) Enforce the short-enums policy across all of clang, GCC and bindgen (#168)
 * Fix the crate build when defmt is enabled (#166)

--- a/mbedtls-rs-sys/gen/builder.rs
+++ b/mbedtls-rs-sys/gen/builder.rs
@@ -872,7 +872,7 @@ impl CMakeConfigurer {
                 "riscv32imafc-unknown-none-elf" | "riscv32imafc-esp-espidf" => &[
                     "--target=riscv32-esp-elf",
                     "-march=rv32imafc",
-                    "-mabi=ilp32",
+                    "-mabi=ilp32f",
                 ],
                 "xtensa-esp32-none-elf" | "xtensa-esp32-espidf" => {
                     &["--target=xtensa-esp-elf", "-mcpu=esp32"]
@@ -894,7 +894,7 @@ impl CMakeConfigurer {
                     &["-march=rv32imac", "-mabi=ilp32"]
                 }
                 "riscv32imafc-unknown-none-elf" | "riscv32imafc-esp-espidf" => {
-                    &["-march=rv32imafc", "-mabi=ilp32"]
+                    &["-march=rv32imafc", "-mabi=ilp32f"]
                 }
                 "xtensa-esp32-none-elf" | "xtensa-esp32-espidf" => &["-mlongcalls"],
                 "xtensa-esp32s2-none-elf" | "xtensa-esp32s2-espidf" => &["-mlongcalls"],


### PR DESCRIPTION
## The bug

`riscv32imafc-unknown-none-elf` is a hard-float target. rustc's own spec for it reads:

```json
"features":     "+m,+a,+c,+f",
"llvm-abiname": "ilp32f",
```

but `CMakeConfigurer` passes `-mabi=ilp32` for that triple, in **both** the clang branch (`gen/builder.rs:872`) and the GCC branch (`gen/builder.rs:896`). The C half of the build therefore uses a soft-float ABI while the Rust half uses hard-float, and linking the two fails:

```
rust-lld: error: <obj>: cannot link object files with different floating-point ABI
```

The `f` in the triple is exactly the difference between `ilp32` and `ilp32f`. The `riscv32imac-*` arms just above are genuinely soft-float and correctly keep `ilp32` — only the two `riscv32imafc-*` arms are wrong.

## Impact

This two-word change is the entire delta between "mbedtls-rs does not build for the ESP32-P4 / ESP32-S31" and "it does". There is no per-chip enablement behind it, because the chip features in this crate only select hardware-crypto hooks.

## Workaround this replaces

Downstreams can work around it today with

```toml
[env]
CFLAGS_riscv32imafc_unknown_none_elf = "-march=rv32imafc -mabi=ilp32f"
```

since cc-rs appends `CFLAGS_<target>` after its own derived flags and GCC honours the last `-mabi`. We have been carrying exactly that in a downstream `.cargo/config.toml` while building a `no_std` ESP32-S31 firmware against this crate; the patch makes it unnecessary.

## Related, not fixed here

cc-rs has the same bug one layer down: it hard-codes soft-float for every non-Linux `riscv32` regardless of the `f` feature, so anything reaching cc-rs directly for this target hits it too. Out of scope for this PR.

## Note on the changelog

I added an `[Unreleased]` section per the Keep a Changelog format the file cites. If you prefer to roll entries up at release time — which is what the history looks like — say so and I will drop that commit.