### PR TITLE
docs: note that certificate validity dates are unchecked without hook-wall-clock

### DIFF
--- a/mbedtls-rs-sys/README.md
+++ b/mbedtls-rs-sys/README.md
@@ -63,6 +63,12 @@ For that reason, `mbedtls-rs-sys` provides the so called Hooking mechanism, curr
 - The ECP scalar multiplication (`R = m * P`) and public-key (point-on-curve) check, through which all ECDH / ECDSA / ECJPAKE (and generic SPAKE2+-style protocol) math funnels (`hook_ecp_mul`, `hook_ecp_verify`)
 - The MPI (bignum) modular exponentiation used by RSA and DHM (`hook_exp_mod`)
 
+Besides the hardware-acceleration hooks above, two further hooks supply platform facilities that MbedTLS cannot obtain by itself on a baremetal target:
+- A monotonic timer, for DTLS retransmission timeouts (`hook_timer`, behind the `hook-timer` feature)
+- A wall clock, for X.509 certificate time validation (`hook_wall_clock`, behind the `hook-wall-clock` feature, which enables `hook-timer` too)
+
+**The wall clock hook has a security consequence and is off by default.** Without the `hook-wall-clock` feature, `MBEDTLS_HAVE_TIME_DATE` is undefined, so the `notBefore` / `notAfter` window of a certificate is not checked at all: an expired or not-yet-valid peer certificate is accepted even when verification is otherwise required. Chain, signature and hostname verification are unaffected. Enable `hook-wall-clock` and install an `MbedtlsWallClock` (plus an `MbedtlsTimer`) before any X.509 use to get the date checks; with the feature enabled and no clock installed, validation fails closed.
+
 In essence Hooking relies on the "_ALT" functionality in MbedTLS and specifically does the following:
 - It replaces e.g. the `mbedtls_sha1_context` of MbedTLS with a custom one which is just a sequence of bytes (called a "work area" throughout `mbedtls-rs-sys`)
   - The exact number of bytes of the work area depends on the concrete algorithm being hooked, but the size **IS** hard-coded yet chosen large enough to be "good enough" for any Rust based HW-accel implementation

--- a/mbedtls-rs/README.md
+++ b/mbedtls-rs/README.md
@@ -5,6 +5,12 @@ Rust library implementing transparent TLS encryption/decryption for IO streams.
 
 Uses MbedTLS 3.X under the hood, via `mbedtls-rs-sys`.
 
+## Certificate validity dates
+
+By default the `notBefore` / `notAfter` window of a peer certificate is **not** checked, so an expired or not-yet-valid certificate is accepted even under `AuthMode::Required`. Chain, signature and hostname verification are unaffected.
+
+This is because `MBEDTLS_HAVE_TIME_DATE` is off unless the `hook-wall-clock` feature is enabled: a `no_std` target has no wall clock unless the consumer supplies one. To enable the date checks, turn on `hook-wall-clock` and install an `MbedtlsWallClock` implementation (plus an `MbedtlsTimer`, which `hook-wall-clock` enables) before any X.509 use. With the feature enabled and no clock installed, validation fails closed.
+
 Example (see all in the `examples` folder):
 ```rust
 //! A platform-agnostic HTTPS 1.0 request-response client using the async API.

--- a/mbedtls-rs/src/session.rs
+++ b/mbedtls-rs/src/session.rs
@@ -108,6 +108,20 @@ pub(crate) fn check_saved_session_server_name(
 }
 
 /// Certificate verification mode used for a session
+///
+/// # Certificate validity dates are not checked by default
+///
+/// `MBEDTLS_HAVE_TIME_DATE` is off unless the `hook-wall-clock` feature is
+/// enabled, so the `notBefore` / `notAfter` window is **not** verified: an
+/// expired or not-yet-valid peer certificate is accepted even under
+/// [`AuthMode::Required`]. Chain, signature and hostname verification are
+/// unaffected.
+///
+/// This is the default because a `no_std` target has no wall clock unless the
+/// consumer supplies one. To enable the checks, turn on `hook-wall-clock` and
+/// install an `MbedtlsWallClock` implementation (plus an `MbedtlsTimer`, which
+/// `hook-wall-clock` pulls in) before any X.509 use. With the feature enabled
+/// and no clock installed, verification fails closed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum AuthMode {


### PR DESCRIPTION
Documents the default X.509 date-validation behaviour discussed in #172.

`MBEDTLS_HAVE_TIME_DATE` is in `ALWAYS_OFF` (`gen/features.rs`), so on a default build `mbedtls_x509_time_is_past()` and `mbedtls_x509_time_is_future()` compile to an unconditional `return 0`:

```
00000000 <mbedtls_x509_time_is_past>:
   8:   4501    li   a0,0
   c:   8082    ret
```

The `notBefore` / `notAfter` window is therefore never checked, and an expired or not-yet-valid peer certificate is accepted even under `AuthMode::Required`. Chain, signature and hostname verification are unaffected.

The behaviour itself looks right for `no_std`, and `hook-wall-clock` re-enables the checks via `generate_user_config()` applying hooks after `apply_features()`. What was missing was any signposting:

- `AuthMode::Required` says the peer "must present a valid certificate", with no mention that the validity window is excluded.
- `hook-wall-clock` and `hook-timer` appear in neither README. The `mbedtls-rs-sys` hooking section lists only the hardware-acceleration hooks.
- The `MbedtlsWallClock` docs do explain the fail-closed case from #149, but the module is behind `#[cfg(feature = "hook-wall-clock")]`, so they are unreachable to anyone who has not already enabled the feature they would be looking for.

## Changes

Documentation only. No code, feature or behaviour changes.

- `mbedtls-rs/src/session.rs` - caveat on the `AuthMode` enum docs, where a reader choosing a verification mode will see it.
- `mbedtls-rs/README.md` - short "Certificate validity dates" section.
- `mbedtls-rs-sys/README.md` - adds `hook_timer` and `hook_wall_clock` to the hooking list, separated from the HW-accel hooks since they supply platform facilities rather than acceleration, with the security consequence called out.

Each place states that enabling the feature without installing a clock fails closed, so nobody reads this as "enable it and you are done".

## Separate finding, not addressed here

`MbedtlsWallClock` is absent from docs.rs entirely:

- `https://docs.rs/mbedtls-rs-sys/0.2.0/mbedtls_rs_sys/hook/` returns 200
- `https://docs.rs/mbedtls-rs-sys/0.2.0/mbedtls_rs_sys/hook/wall_clock/` returns 404

Neither crate has a `[package.metadata.docs.rs]` section, so docs.rs builds with default features (`default = ["tls"]`), and the `#[cfg]`-gated module never renders. A `features = ["hook-wall-clock"]` entry would fix it.

I have deliberately left that out of this PR: it is a build-configuration change rather than documentation, and I could not verify a docs.rs build locally. `all-features = true` would not be the right form, since the `esp32*` features select mutually exclusive `esp-hal` chips. Happy to add it in a follow-up if you want it.

## Verification

`cargo fmt --check -p mbedtls-rs` passes. The intra-doc link style matches the existing `[mbedtls_ssl_get_verify_result()]` reference in the neighbouring variant.
