### PR TITLE
Add `ClientSessionConfig::skip_hostname_verification`

### DIFF
--- a/mbedtls-rs/CHANGELOG.md
+++ b/mbedtls-rs/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+* Add `ClientSessionConfig::skip_hostname_verification`: skip the certificate hostname (CN/SAN) check while still sending SNI and verifying the certificate chain, mirroring esp-idf's `skip_cert_common_name_check` (#174)
+
 ## [0.2.0] - 2026-08-20
 * (Breaking) Enforce the short-enums policy across all of clang, GCC and bindgen (#168)
 * Fix the crate build when defmt is enabled (#166)

--- a/mbedtls-rs/CHANGELOG.md
+++ b/mbedtls-rs/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-* Add `ClientSessionConfig::skip_hostname_verification`: skip the certificate hostname (CN/SAN) check while still sending SNI and verifying the certificate chain, mirroring esp-idf's `skip_cert_common_name_check` (#174)
+* (Breaking) Add `ClientSessionConfig::skip_hostname_verification`: skip the certificate hostname (CN/SAN) check while still sending SNI and verifying the certificate chain, mirroring esp-idf's `skip_cert_common_name_check` (#174)
 
 ## [0.2.0] - 2026-08-20
 * (Breaking) Enforce the short-enums policy across all of clang, GCC and bindgen (#168)

--- a/mbedtls-rs/src/session.rs
+++ b/mbedtls-rs/src/session.rs
@@ -166,6 +166,14 @@ pub struct ClientSessionConfig<'a> {
     pub min_version: TlsVersion,
     /// ALPN protocols
     pub alpn_protocols: Option<&'a [&'a CStr]>,
+    /// Skip the certificate hostname (CN/SAN) match check while still sending
+    /// SNI (`server_name`) and verifying the rest of the certificate chain.
+    ///
+    /// Equivalent to esp-idf's `skip_cert_common_name_check`: use this when
+    /// the server certificate does not match the hostname used to reach the
+    /// server (e.g. pinned or self-signed certificates served behind a
+    /// different domain).
+    pub skip_hostname_verification: bool,
 }
 
 impl<'a> Default for ClientSessionConfig<'a> {
@@ -183,6 +191,7 @@ impl<'a> ClientSessionConfig<'a> {
             auth_mode: AuthMode::Required,
             min_version: TlsVersion::Tls1_2,
             alpn_protocols: None,
+            skip_hostname_verification: false,
         }
     }
 }
@@ -415,6 +424,18 @@ impl<'a> SessionState<'a> {
             if let Some(name) = conf.server_name {
                 merr!(unsafe { mbedtls_ssl_set_hostname(&mut *ssl_context, name.as_ptr()) })?;
             }
+            // SNI is still sent (`set_hostname` above), but the verify callback
+            // clears the leaf certificate's CN/SAN mismatch flag. The rest of the
+            // chain verification is not affected.
+            if conf.skip_hostname_verification {
+                unsafe {
+                    mbedtls_ssl_conf_verify(
+                        &mut *ssl_config,
+                        Some(verify_skip_hostname_mismatch),
+                        core::ptr::null_mut(),
+                    );
+                }
+            }
         }
 
         Ok(Self {
@@ -426,6 +447,21 @@ impl<'a> SessionState<'a> {
             _alpn_ptrs: alpn,
         })
     }
+}
+
+/// Clears the hostname mismatch flag of the leaf certificate (depth 0). All
+/// other verification flags are left untouched and are still evaluated by
+/// MbedTLS according to the configured [AuthMode].
+unsafe extern "C" fn verify_skip_hostname_mismatch(
+    _ctx: *mut c_void,
+    _crt: *mut mbedtls_x509_crt,
+    depth: c_int,
+    flags: *mut u32,
+) -> c_int {
+    if depth == 0 && !flags.is_null() {
+        unsafe { *flags &= !MBEDTLS_X509_BADCERT_CN_MISMATCH };
+    }
+    0
 }
 
 /// Error type for session operations


### PR DESCRIPTION
## Motivation

Closes #54.

Some deployments have to reach a server whose certificate does not contain the hostname used to reach it — pinned or self-signed certificates, brokers reached through a different domain, IP endpoints, etc. esp-idf exposes `skip_cert_common_name_check` in `esp_tls_cfg_t` for exactly this situation.

`mbedtls-rs` currently only offers an all-or-nothing choice: keep `AuthMode::Required` and fail the handshake with `MBEDTLS_X509_BADCERT_CN_MISMATCH` (-9984, as reported in #54), or drop to `AuthMode::None` and lose chain verification entirely.

## What this does

Adds an opt-in `skip_hostname_verification: bool` (default `false`) to `ClientSessionConfig`:

- SNI is unaffected — `mbedtls_ssl_set_hostname` is still called with `server_name`, so servers relying on SNI keep working.
- When enabled, a verify callback is registered via `mbedtls_ssl_conf_verify` that clears only the `MBEDTLS_X509_BADCERT_CN_MISMATCH` flag, and only on the leaf certificate (depth 0).
- Everything else is untouched: chain-of-trust, expiry and all other verification flags are still evaluated by MbedTLS according to the configured `auth_mode`.

This is the same shape as the workaround posted in #54, offered as a first-class API so users don't each have to hand-roll an `unsafe extern "C"` callback.

Note on semver: adding a public field is technically breaking for code that builds `ClientSessionConfig` with struct-literal syntax (construction through `new()`/`Default` is unaffected). Happy to mark the changelog entry `(Breaking)` or adjust otherwise if you prefer.

## Testing

- `cargo fmt -- --check`, `cargo clippy -- -D warnings`, `cargo build`, `cargo test` and `cargo check -p mbedtls-rs --features defmt` all pass locally (same commands as CI).
- An equivalent patch (applied on top of the released 0.1.0) has been running in a production ESP32-C5 firmware, connecting with `AuthMode::Required` and a pinned CA to a server whose certificate CN does not match the connection hostname; the chain is still verified, only the hostname check is skipped.
