### PR TITLE
Add a client key-exchange group allowlist

### DIFF
--- a/mbedtls-rs/CHANGELOG.md
+++ b/mbedtls-rs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add an opt-in `ecp-restartable` feature: async sessions turn in-progress restartable ECC operations into cooperative yields, blocking sessions retry them to completion, and `ecp::set_restartable_max_ops` configures the process-wide operation budget; the in-progress result is handled unconditionally, so ESP-IDF builds with `CONFIG_MBEDTLS_ECP_RESTARTABLE` get the same behaviour
 * (Breaking) Add an optional `max_version` to `ClientSessionConfig`; capping at TLS 1.2 is what lets a restartable client yield, as Mbed TLS 3.6's TLS 1.3 handshake crypto is not restartable
 * Add `Session::new_with_yield` to the blocking session: a platform yield hook (e.g. `std::thread::yield_now`) invoked between restartable-ECC retry slices
+* (Breaking) Add an optional ordered key-exchange group allowlist (`key_exchange_groups`, `TlsGroup`) to `ClientSessionConfig`
 
 ## [0.2.0] - 2026-08-20
 * (Breaking) Enforce the short-enums policy across all of clang, GCC and bindgen (#168)

--- a/mbedtls-rs/src/session.rs
+++ b/mbedtls-rs/src/session.rs
@@ -191,6 +191,8 @@ pub struct ClientSessionConfig<'a> {
     /// server (e.g. pinned or self-signed certificates served behind a
     /// different domain).
     pub skip_hostname_verification: bool,
+    /// Ordered key-exchange groups to offer. `None` keeps Mbed TLS's defaults.
+    pub key_exchange_groups: Option<&'static [TlsGroup]>,
 }
 
 impl<'a> Default for ClientSessionConfig<'a> {
@@ -210,7 +212,39 @@ impl<'a> ClientSessionConfig<'a> {
             max_version: None,
             alpn_protocols: None,
             skip_hostname_verification: false,
+            key_exchange_groups: None,
         }
+    }
+}
+
+/// A named group that can be offered during TLS key exchange.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u16)]
+pub enum TlsGroup {
+    Secp192k1 = MBEDTLS_SSL_IANA_TLS_GROUP_SECP192K1 as u16,
+    Secp192r1 = MBEDTLS_SSL_IANA_TLS_GROUP_SECP192R1 as u16,
+    Secp224k1 = MBEDTLS_SSL_IANA_TLS_GROUP_SECP224K1 as u16,
+    Secp224r1 = MBEDTLS_SSL_IANA_TLS_GROUP_SECP224R1 as u16,
+    Secp256k1 = MBEDTLS_SSL_IANA_TLS_GROUP_SECP256K1 as u16,
+    Secp256r1 = MBEDTLS_SSL_IANA_TLS_GROUP_SECP256R1 as u16,
+    Secp384r1 = MBEDTLS_SSL_IANA_TLS_GROUP_SECP384R1 as u16,
+    Secp521r1 = MBEDTLS_SSL_IANA_TLS_GROUP_SECP521R1 as u16,
+    BrainpoolP256r1 = MBEDTLS_SSL_IANA_TLS_GROUP_BP256R1 as u16,
+    BrainpoolP384r1 = MBEDTLS_SSL_IANA_TLS_GROUP_BP384R1 as u16,
+    BrainpoolP512r1 = MBEDTLS_SSL_IANA_TLS_GROUP_BP512R1 as u16,
+    X25519 = MBEDTLS_SSL_IANA_TLS_GROUP_X25519 as u16,
+    X448 = MBEDTLS_SSL_IANA_TLS_GROUP_X448 as u16,
+    Ffdhe2048 = MBEDTLS_SSL_IANA_TLS_GROUP_FFDHE2048 as u16,
+    Ffdhe3072 = MBEDTLS_SSL_IANA_TLS_GROUP_FFDHE3072 as u16,
+    Ffdhe4096 = MBEDTLS_SSL_IANA_TLS_GROUP_FFDHE4096 as u16,
+    Ffdhe6144 = MBEDTLS_SSL_IANA_TLS_GROUP_FFDHE6144 as u16,
+    Ffdhe8192 = MBEDTLS_SSL_IANA_TLS_GROUP_FFDHE8192 as u16,
+}
+
+impl TlsGroup {
+    const fn mbedtls_id(self) -> u16 {
+        self as u16
     }
 }
 
@@ -297,6 +331,16 @@ impl<'a> SessionConfig<'a> {
         }
     }
 
+    fn key_exchange_groups(&self) -> Option<&'static [TlsGroup]> {
+        match self {
+            SessionConfig::Client(ClientSessionConfig {
+                key_exchange_groups,
+                ..
+            }) => *key_exchange_groups,
+            SessionConfig::Server { .. } => None,
+        }
+    }
+
     fn raw_mode(&self) -> c_int {
         match self {
             Self::Client { .. } => MBEDTLS_SSL_IS_CLIENT as c_int,
@@ -343,6 +387,31 @@ impl<'a> Drop for ALPNArray<'a> {
     }
 }
 
+/// Owned, zero-terminated group-ID array allocated through Mbed TLS.
+struct GroupArray(NonNull<u16>);
+
+impl GroupArray {
+    fn from_slice(groups: &[TlsGroup]) -> Option<Self> {
+        let count = groups.len().checked_add(1)?;
+        let ptr = NonNull::new(unsafe { mbedtls_calloc(count, size_of::<u16>()) }.cast::<u16>())?;
+        let output = unsafe { core::slice::from_raw_parts_mut(ptr.as_ptr(), groups.len()) };
+        for (output, group) in output.iter_mut().zip(groups) {
+            *output = group.mbedtls_id();
+        }
+        Some(Self(ptr))
+    }
+
+    fn as_ptr(&self) -> *const u16 {
+        self.0.as_ptr()
+    }
+}
+
+impl Drop for GroupArray {
+    fn drop(&mut self) {
+        unsafe { mbedtls_free(self.0.as_ptr().cast::<c_void>()) }
+    }
+}
+
 /// Session state
 struct SessionState<'a> {
     /// The SSL context
@@ -372,6 +441,10 @@ struct SessionState<'a> {
     /// While not explicitly used, we need to keep a reference to it as it is used
     /// by the SSL context via a raw pointer
     _alpn_ptrs: Option<ALPNArray<'a>>,
+    /// Key-exchange group IDs referenced by the SSL configuration.
+    ///
+    /// This must remain after `ssl_context` and `_ssl_config` so Rust drops those fields first.
+    _group_ids: Option<GroupArray>,
 }
 
 impl<'a> SessionState<'a> {
@@ -433,6 +506,18 @@ impl<'a> SessionState<'a> {
             None
         };
 
+        let group_ids = if let Some(groups) = conf.key_exchange_groups() {
+            if groups.is_empty() {
+                return Err(MbedtlsError::new(MBEDTLS_ERR_SSL_BAD_INPUT_DATA));
+            }
+            let group_ids = GroupArray::from_slice(groups)
+                .ok_or(MbedtlsError::new(MBEDTLS_ERR_SSL_ALLOC_FAILED))?;
+            unsafe { mbedtls_ssl_conf_groups(&mut *ssl_config, group_ids.as_ptr()) };
+            Some(group_ids)
+        } else {
+            None
+        };
+
         let mut drbg_context =
             MBox::new().ok_or(MbedtlsError::new(MBEDTLS_ERR_SSL_ALLOC_FAILED))?;
 
@@ -474,6 +559,7 @@ impl<'a> SessionState<'a> {
             _ca_chain: conf.ca_chain().cloned(),
             _creds: conf.creds().cloned(),
             _alpn_ptrs: alpn,
+            _group_ids: group_ids,
         })
     }
 }

--- a/mbedtls-rs/src/session.rs
+++ b/mbedtls-rs/src/session.rs
@@ -192,7 +192,7 @@ pub struct ClientSessionConfig<'a> {
     /// different domain).
     pub skip_hostname_verification: bool,
     /// Ordered key-exchange groups to offer. `None` keeps Mbed TLS's defaults.
-    pub key_exchange_groups: Option<&'static [TlsGroup]>,
+    pub key_exchange_groups: Option<&'a [TlsGroup]>,
 }
 
 impl<'a> Default for ClientSessionConfig<'a> {
@@ -331,7 +331,7 @@ impl<'a> SessionConfig<'a> {
         }
     }
 
-    fn key_exchange_groups(&self) -> Option<&'static [TlsGroup]> {
+    fn key_exchange_groups(&self) -> Option<&'a [TlsGroup]> {
         match self {
             SessionConfig::Client(ClientSessionConfig {
                 key_exchange_groups,

--- a/mbedtls-rs/tests/key_exchange_groups.rs
+++ b/mbedtls-rs/tests/key_exchange_groups.rs
@@ -1,0 +1,268 @@
+// Regenerate the fixtures with:
+// openssl ecparam -name prime256v1 -genkey -noout -out key.pem
+// openssl req -x509 -key key.pem -out cert.pem -sha256 -days 36500 -subj "/CN=mbedtls-rs.local" -addext "subjectAltName=DNS:mbedtls-rs.local"
+// openssl x509 -in cert.pem -outform der -out cert.der
+// openssl pkcs8 -topk8 -nocrypt -in key.pem -outform der -out key.der
+
+use core::convert::Infallible;
+use std::net::{TcpListener, TcpStream};
+use std::sync::mpsc::channel;
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+use mbedtls_rs::blocking::io::{ErrorKind, ErrorType, Read, Write};
+use mbedtls_rs::blocking::Session;
+use mbedtls_rs::sys::MbedtlsError;
+use mbedtls_rs::{
+    Certificate, ClientSessionConfig, Credentials, PrivateKey, ServerSessionConfig, SessionConfig,
+    SessionError, Tls, TlsGroup, TlsReference, X509,
+};
+use rand::{Rng, TryCryptoRng, TryRng};
+
+const CERTIFICATE: &[u8] = include_bytes!("fixtures/cert.der");
+const PRIVATE_KEY: &[u8] = include_bytes!("fixtures/key.der");
+const PAYLOAD: &[u8] = b"real mbedtls-rs key exchange groups";
+const MBEDTLS_ERR_SSL_BAD_INPUT_DATA: i32 = -0x7100;
+
+static GROUPS: [TlsGroup; 1] = [TlsGroup::Secp256r1];
+
+// Tls owns a process-global RNG callback, so tests must not overlap Tls lifetimes.
+static SERIAL: Mutex<()> = Mutex::new(());
+
+fn serialize_tls_lifetimes() -> MutexGuard<'static, ()> {
+    SERIAL.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+struct StdRng;
+
+impl TryRng for StdRng {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok(rand::rng().next_u32())
+    }
+
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        Ok(rand::rng().next_u64())
+    }
+
+    fn try_fill_bytes(&mut self, destination: &mut [u8]) -> Result<(), Self::Error> {
+        rand::rng().fill_bytes(destination);
+        Ok(())
+    }
+}
+
+impl TryCryptoRng for StdRng {}
+
+/// A stream that never carries any bytes, for the session-creation-only tests.
+struct IdleStream;
+
+impl ErrorType for IdleStream {
+    type Error = Infallible;
+}
+
+impl Read for IdleStream {
+    fn read(&mut self, _buffer: &mut [u8]) -> Result<usize, Self::Error> {
+        Ok(0)
+    }
+}
+
+impl Write for IdleStream {
+    fn write(&mut self, buffer: &[u8]) -> Result<usize, Self::Error> {
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+/// `embedded-io` adapter over a `std` TCP stream. Both `embedded_io::Error for
+/// std::io::Error` and the `std::io::ErrorKind` conversion live behind the
+/// `embedded-io` crate's `std` feature, which this crate does not enable, so the
+/// stream reports an `ErrorKind` mapped by hand.
+struct TcpEndpoint(TcpStream);
+
+fn io_error_kind(error: std::io::Error) -> ErrorKind {
+    match error.kind() {
+        std::io::ErrorKind::BrokenPipe => ErrorKind::BrokenPipe,
+        std::io::ErrorKind::ConnectionAborted => ErrorKind::ConnectionAborted,
+        std::io::ErrorKind::ConnectionReset => ErrorKind::ConnectionReset,
+        std::io::ErrorKind::Interrupted => ErrorKind::Interrupted,
+        std::io::ErrorKind::NotConnected => ErrorKind::NotConnected,
+        std::io::ErrorKind::TimedOut => ErrorKind::TimedOut,
+        _ => ErrorKind::Other,
+    }
+}
+
+impl ErrorType for TcpEndpoint {
+    type Error = ErrorKind;
+}
+
+impl Read for TcpEndpoint {
+    fn read(&mut self, buffer: &mut [u8]) -> Result<usize, Self::Error> {
+        std::io::Read::read(&mut self.0, buffer).map_err(io_error_kind)
+    }
+}
+
+impl Write for TcpEndpoint {
+    fn write(&mut self, buffer: &[u8]) -> Result<usize, Self::Error> {
+        std::io::Write::write(&mut self.0, buffer).map_err(io_error_kind)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        std::io::Write::flush(&mut self.0).map_err(io_error_kind)
+    }
+}
+
+fn write_all<T: Read + Write>(session: &mut Session<'_, T>, mut buffer: &[u8]) {
+    while !buffer.is_empty() {
+        let written = session.write(buffer).unwrap();
+        assert!(written > 0, "TLS stream accepted no bytes");
+        buffer = &buffer[written..];
+    }
+}
+
+fn read_exact<T: Read + Write>(session: &mut Session<'_, T>, mut buffer: &mut [u8]) {
+    while !buffer.is_empty() {
+        let read = session.read(buffer).unwrap();
+        assert!(read > 0, "TLS stream reached EOF before the echo completed");
+        buffer = &mut buffer[read..];
+    }
+}
+
+fn server_config() -> SessionConfig<'static> {
+    SessionConfig::Server(ServerSessionConfig::new(Credentials {
+        certificate: Certificate::new_no_copy(CERTIFICATE).unwrap(),
+        private_key: PrivateKey::new(X509::DER(PRIVATE_KEY), None).unwrap(),
+    }))
+}
+
+fn client_config() -> SessionConfig<'static> {
+    SessionConfig::Client(ClientSessionConfig {
+        ca_chain: Some(Certificate::new_no_copy(CERTIFICATE).unwrap()),
+        server_name: Some(c"mbedtls-rs.local"),
+        key_exchange_groups: Some(&GROUPS),
+        ..ClientSessionConfig::new()
+    })
+}
+
+fn idle_session_is_created(
+    tls_reference: TlsReference<'_>,
+    key_exchange_groups: Option<&'static [TlsGroup]>,
+) -> Result<(), SessionError> {
+    let config = SessionConfig::Client(ClientSessionConfig {
+        key_exchange_groups,
+        ..ClientSessionConfig::new()
+    });
+
+    Session::new(tls_reference, IdleStream, &config).map(drop)
+}
+
+#[test]
+fn tls_groups_use_the_mbed_tls_iana_ids() {
+    let groups = [
+        (TlsGroup::Secp192k1, 18),
+        (TlsGroup::Secp192r1, 19),
+        (TlsGroup::Secp224k1, 20),
+        (TlsGroup::Secp224r1, 21),
+        (TlsGroup::Secp256k1, 22),
+        (TlsGroup::Secp256r1, 23),
+        (TlsGroup::Secp384r1, 24),
+        (TlsGroup::Secp521r1, 25),
+        (TlsGroup::BrainpoolP256r1, 26),
+        (TlsGroup::BrainpoolP384r1, 27),
+        (TlsGroup::BrainpoolP512r1, 28),
+        (TlsGroup::X25519, 29),
+        (TlsGroup::X448, 30),
+        (TlsGroup::Ffdhe2048, 256),
+        (TlsGroup::Ffdhe3072, 257),
+        (TlsGroup::Ffdhe4096, 258),
+        (TlsGroup::Ffdhe6144, 259),
+        (TlsGroup::Ffdhe8192, 260),
+    ];
+
+    for (group, expected) in groups {
+        assert_eq!(group as u16, expected);
+    }
+}
+
+#[test]
+fn client_defaults_leave_key_exchange_groups_unset() {
+    assert_eq!(ClientSessionConfig::new().key_exchange_groups, None);
+}
+
+#[test]
+fn empty_group_allowlist_is_rejected_at_session_creation() {
+    let _serial = serialize_tls_lifetimes();
+    let mut rng = StdRng;
+    // SAFETY: `rng` is declared before `tls`, and every session and `tls` are
+    // dropped in this scope before the borrowed RNG can go out of scope.
+    let tls = unsafe { Tls::new_local_borrows(&mut rng) }.unwrap();
+
+    let error = idle_session_is_created(tls.reference(), Some(&[])).unwrap_err();
+
+    assert_eq!(
+        error,
+        SessionError::MbedTls(MbedtlsError::new(MBEDTLS_ERR_SSL_BAD_INPUT_DATA))
+    );
+}
+
+#[test]
+fn session_with_a_group_allowlist_is_created_and_dropped() {
+    let _serial = serialize_tls_lifetimes();
+    let mut rng = StdRng;
+    // SAFETY: `rng` is declared before `tls`, and every session and `tls` are
+    // dropped in this scope before the borrowed RNG can go out of scope.
+    let tls = unsafe { Tls::new_local_borrows(&mut rng) }.unwrap();
+
+    static ALLOWLIST: [TlsGroup; 2] = [TlsGroup::Secp256r1, TlsGroup::Secp384r1];
+    let created = idle_session_is_created(tls.reference(), Some(&ALLOWLIST));
+
+    assert!(created.is_ok(), "session creation failed: {created:?}");
+}
+
+#[test]
+fn handshake_completes_with_a_group_allowlist() {
+    let _serial = serialize_tls_lifetimes();
+    let mut rng = StdRng;
+    // SAFETY: `rng` is declared before `tls`, and every session and `tls` are
+    // dropped in this scope before the borrowed RNG can go out of scope.
+    let tls = unsafe { Tls::new_local_borrows(&mut rng) }.unwrap();
+    let tls_reference = tls.reference();
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    // The client signals completion by dropping its sender, so the server keeps
+    // its TCP stream open until the client has sent its own close notify.
+    let (client_done_sender, client_done_receiver) = channel::<()>();
+
+    std::thread::scope(|scope| {
+        let server = scope.spawn(move || {
+            let (stream, _peer) = listener.accept().unwrap();
+            let mut session =
+                Session::new(tls_reference, TcpEndpoint(stream), &server_config()).unwrap();
+            session.connect().unwrap();
+            let mut received = [0; PAYLOAD.len()];
+            read_exact(&mut session, &mut received);
+            assert_eq!(received, PAYLOAD);
+            write_all(&mut session, &received);
+            session.close().unwrap();
+            let _ = client_done_receiver.recv();
+        });
+        let client = scope.spawn(move || {
+            let stream = TcpStream::connect(address).unwrap();
+            let mut session =
+                Session::new(tls_reference, TcpEndpoint(stream), &client_config()).unwrap();
+            session.connect().unwrap();
+            write_all(&mut session, PAYLOAD);
+            let mut echoed = [0; PAYLOAD.len()];
+            read_exact(&mut session, &mut echoed);
+            assert_eq!(echoed, PAYLOAD);
+            session.close().unwrap();
+            drop(client_done_sender);
+        });
+
+        server.join().unwrap();
+        client.join().unwrap();
+    });
+}

--- a/mbedtls-rs/tests/key_exchange_groups.rs
+++ b/mbedtls-rs/tests/key_exchange_groups.rs
@@ -148,7 +148,7 @@ fn client_config() -> SessionConfig<'static> {
 
 fn idle_session_is_created(
     tls_reference: TlsReference<'_>,
-    key_exchange_groups: Option<&'static [TlsGroup]>,
+    key_exchange_groups: Option<&[TlsGroup]>,
 ) -> Result<(), SessionError> {
     let config = SessionConfig::Client(ClientSessionConfig {
         key_exchange_groups,


### PR DESCRIPTION
## Summary

This adds an optional, ordered key-exchange group allowlist to `ClientSessionConfig`, split out of the original #170 pull-request.

`key_exchange_groups: Option<&'static [TlsGroup]>` lets an application state which named groups the client offers, in preference order. The IANA group IDs are copied into zero-terminated storage owned by the session state - as `mbedtls_ssl_conf_groups` requires the array to outlive the configuration - and handed to Mbed TLS during session creation. `None` (the default) preserves Mbed TLS's own group defaults; an empty allowlist is rejected at session creation with `MBEDTLS_ERR_SSL_BAD_INPUT_DATA`.

`TlsGroup` is a `#[repr(u16)]` enum over the `MBEDTLS_SSL_IANA_TLS_GROUP_*` constants (the NIST, Brainpool, Montgomery and FFDHE groups Mbed TLS knows about).

## Motivation

Group selection is application policy: pinning a deployment to the curves its peers and hardware accelerators actually support, or excluding a group for compliance reasons. It also pairs naturally with #170 - Mbed TLS documents that the restartable-ECC operation budget is ignored by Curve25519/448, so an application that wants bounded ECC slices needs to be able to keep the key exchange on a short-Weierstrass curve - but nothing here depends on that feature, which is why it is a separate PR.

## Changes

- Add `TlsGroup` and `ClientSessionConfig::key_exchange_groups`.
- Add an owned, zero-terminated group-ID array to the session state, allocated through Mbed TLS's allocator and dropped after the SSL context and configuration that reference it.
- Reject an empty allowlist at session creation.
- Add an `Unreleased` changelog entry.

Nothing selects a group automatically; `None` leaves Mbed TLS's defaults untouched.

## Example

```rust
use mbedtls_rs::{ClientSessionConfig, Session, SessionConfig, TlsGroup};

static GROUPS: &[TlsGroup] = &[TlsGroup::Secp256r1, TlsGroup::Secp384r1];

let config = SessionConfig::Client(ClientSessionConfig {
    key_exchange_groups: Some(GROUPS),
    ..ClientSessionConfig::new()
});

let mut session = Session::new(tls.reference(), stream, &config)?;
session.connect().await?;
```

## Compatibility

- `key_exchange_groups` defaults to `None`, so existing configurations negotiate exactly as before.
- Adding a public field to the all-public `ClientSessionConfig` is a breaking change for struct literals built without `..`, so the release containing this should bump the minor version (0.3, given 0.2.0 is released). The changelog entry is marked `(Breaking)` accordingly.
- No `mbedtls-rs-sys` changes: `mbedtls_ssl_conf_groups` and the IANA group constants are already in the bindings.

## Relationship to #170

The two PRs are independent and can merge in either order. They share only a byte-identical `[dev-dependencies]` block and identical test fixtures (which merge cleanly), plus the new `## [Unreleased]` changelog heading - whichever lands second will need a one-line changelog rebase, which I'll do promptly.

## Validation

- `cargo fmt --all --check`
- `cargo test --features use-gcc`
- `cargo clippy -p mbedtls-rs --all-targets --features use-gcc -- -D warnings`
- `cargo clippy --features use-gcc -- -D warnings`
- `cargo check -p mbedtls-rs --features defmt,use-gcc`

(`use-gcc` because the development machine has no clang C compiler; environments with clang can drop it.)

Tests exercise the real code paths rather than a model: the `TlsGroup` discriminants match the Mbed TLS IANA IDs; the default leaves the allowlist unset; an empty allowlist is rejected by the real constructor; a session with a two-group allowlist is created and dropped (allocation and drop order of the owned array); and a real blocking handshake with a P-256-only allowlist completes and echoes a payload over a localhost TCP loopback against committed self-signed ECDSA P-256 fixtures.

## Contribution terms

This contribution is submitted under the repository's existing dual MIT OR Apache-2.0 licensing terms, without additional terms or conditions.
