### PR TITLE
Option to fetch the negotiated TLS version

### DIFF
--- a/mbedtls-rs/CHANGELOG.md
+++ b/mbedtls-rs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * (Breaking) Add an optional `max_version` to `ClientSessionConfig`; capping at TLS 1.2 is what lets a restartable client yield, as Mbed TLS 3.6's TLS 1.3 handshake crypto is not restartable
 * Add `Session::new_with_yield` to the blocking session: a platform yield hook (e.g. `std::thread::yield_now`) invoked between restartable-ECC retry slices
 * (Breaking) Add an optional ordered key-exchange group allowlist (`key_exchange_groups`, `TlsGroup`) to `ClientSessionConfig`
+* Add `Session::tls_version` (blocking and async): the TLS protocol version negotiated during the handshake, `None` until a `connect()` succeeds (#167)
 
 ## [0.2.0] - 2026-08-20
 * (Breaking) Enforce the short-enums policy across all of clang, GCC and bindgen (#168)

--- a/mbedtls-rs/src/lib.rs
+++ b/mbedtls-rs/src/lib.rs
@@ -227,7 +227,7 @@ impl<'d> Drop for Tls<'d> {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TlsReference<'a>(PhantomData<&'a ()>);
 
-/// The minimum TLS version that will be supported by a particular `Session` instance
+/// A TLS protocol version
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TlsVersion {
@@ -242,6 +242,19 @@ impl TlsVersion {
         match self {
             TlsVersion::Tls1_2 => mbedtls_ssl_protocol_version_MBEDTLS_SSL_VERSION_TLS1_2,
             TlsVersion::Tls1_3 => mbedtls_ssl_protocol_version_MBEDTLS_SSL_VERSION_TLS1_3,
+        }
+    }
+
+    /// `None` for `MBEDTLS_SSL_VERSION_UNKNOWN` and for any version this crate does not model
+    fn from_mbed_tls_version(version: mbedtls_ssl_protocol_version) -> Option<Self> {
+        // Not a `match`: the generated constants are lower-case, which reads like a
+        // catch-all binding in pattern position and warns under `non_upper_case_globals`.
+        if version == mbedtls_ssl_protocol_version_MBEDTLS_SSL_VERSION_TLS1_2 {
+            Some(TlsVersion::Tls1_2)
+        } else if version == mbedtls_ssl_protocol_version_MBEDTLS_SSL_VERSION_TLS1_3 {
+            Some(TlsVersion::Tls1_3)
+        } else {
+            None
         }
     }
 }

--- a/mbedtls-rs/src/session/asynch.rs
+++ b/mbedtls-rs/src/session/asynch.rs
@@ -9,7 +9,7 @@ use embedded_io::ErrorKind;
 use io::{ErrorType, Read, Write};
 
 use crate::sys::*;
-use crate::{SessionError, TlsReference};
+use crate::{SessionError, TlsReference, TlsVersion};
 
 use super::{
     check_saved_session_server_name, SavedSession, ServerName, SessionConfig, SessionState,
@@ -110,6 +110,25 @@ where
                 Some(CStr::from_ptr(ptr))
             }
         }
+    }
+
+    /// Get the TLS protocol version negotiated during the handshake.
+    ///
+    /// Returns `None` before a successful `connect()`, and after `close()`.
+    ///
+    /// Use this to confirm which protocol version is actually in use - in
+    /// particular when a peer is only known to behave correctly on a specific
+    /// version, in combination with capping `max_version`.
+    pub fn tls_version(&self) -> Option<TlsVersion> {
+        // Gated on `connected`: MbedTLS seeds this field with the configured maximum
+        // version at setup and on every session reset, so on its own it reports a
+        // version the peers have not actually agreed on yet.
+        //
+        // The field is read directly rather than through `mbedtls_ssl_get_version_number`,
+        // which is a `static inline` and therefore not exposed by bindgen.
+        self.connected
+            .then(|| TlsVersion::from_mbed_tls_version(self.state.ssl_context.private_tls_version))
+            .flatten()
     }
 
     /// Get a mutable reference to the underlying stream

--- a/mbedtls-rs/src/session/blocking.rs
+++ b/mbedtls-rs/src/session/blocking.rs
@@ -6,7 +6,7 @@ use crate::sys::*;
 
 use super::{
     check_saved_session_server_name, SavedSession, ServerName, SessionConfig, SessionError,
-    SessionState, TlsReference,
+    SessionState, TlsReference, TlsVersion,
 };
 
 /// Re-export of the `embedded-io` crate so that users don't have to explicitly depend on it
@@ -223,6 +223,25 @@ where
                 Some(CStr::from_ptr(ptr))
             }
         }
+    }
+
+    /// Get the TLS protocol version negotiated during the handshake.
+    ///
+    /// Returns `None` before a successful `connect()`, and after `close()`.
+    ///
+    /// Use this to confirm which protocol version is actually in use - in
+    /// particular when a peer is only known to behave correctly on a specific
+    /// version, in combination with capping `max_version`.
+    pub fn tls_version(&self) -> Option<TlsVersion> {
+        // Gated on `connected`: MbedTLS seeds this field with the configured maximum
+        // version at setup and on every session reset, so on its own it reports a
+        // version the peers have not actually agreed on yet.
+        //
+        // The field is read directly rather than through `mbedtls_ssl_get_version_number`,
+        // which is a `static inline` and therefore not exposed by bindgen.
+        self.connected
+            .then(|| TlsVersion::from_mbed_tls_version(self.state.ssl_context.private_tls_version))
+            .flatten()
     }
 
     /// Read unencrypted data from the TLS connection

--- a/mbedtls-rs/tests/loopback.rs
+++ b/mbedtls-rs/tests/loopback.rs
@@ -76,6 +76,22 @@ fn server_config() -> SessionConfig<'static> {
     }))
 }
 
+/// A completed handshake must report a version, and a client cap must be exactly
+/// what gets negotiated - the loopback server offers every version the client can
+/// ask for. Called on each end, so both peers are held to the same expectation.
+fn assert_negotiated_version(version: Option<TlsVersion>, maximum_version: Option<TlsVersion>) {
+    assert!(
+        version.is_some(),
+        "no version reported after a successful handshake"
+    );
+    if maximum_version.is_some() {
+        assert_eq!(
+            version, maximum_version,
+            "the negotiated version does not match the client's cap"
+        );
+    }
+}
+
 #[derive(Debug, Default)]
 struct AsyncDirection {
     bytes: RefCell<VecDeque<u8>>,
@@ -241,11 +257,24 @@ fn run_async_loopback(
     .unwrap();
     let mut server = AsyncSession::new(tls_reference, server_stream, &server_config()).unwrap();
 
+    assert_eq!(
+        client.tls_version(),
+        None,
+        "a version was reported before the handshake"
+    );
+
     let handshake_wake = Arc::new(CountingWake(AtomicUsize::new(0)));
     let (client_result, server_result) =
         drive_pair(client.connect(), server.connect(), handshake_wake.clone());
     client_result.unwrap();
     server_result.unwrap();
+
+    assert_eq!(
+        client.tls_version(),
+        server.tls_version(),
+        "peers disagree on the negotiated version"
+    );
+    assert_negotiated_version(client.tls_version(), maximum_version);
 
     let echo_wake = Arc::new(CountingWake(AtomicUsize::new(0)));
     let client_echo = async {
@@ -382,6 +411,10 @@ fn run_blocking_loopback(
             let mut session =
                 BlockingSession::new(tls_reference, server_stream, &server_config()).unwrap();
             session.connect().unwrap();
+            // The discriminating end: the server is never capped, so its seeded
+            // version is the MbedTLS default maximum. Reporting the client's lower
+            // cap here means a genuinely negotiated version is being read.
+            assert_negotiated_version(session.tls_version(), maximum_version);
             let mut received = [0; PAYLOAD.len()];
             blocking_read_exact(&mut session, &mut received);
             assert_eq!(received, PAYLOAD);
@@ -397,7 +430,13 @@ fn run_blocking_loopback(
                 None => BlockingSession::new(tls_reference, client_stream, &config),
             }
             .unwrap();
+            assert_eq!(
+                session.tls_version(),
+                None,
+                "a version was reported before the handshake"
+            );
             session.connect().unwrap();
+            assert_negotiated_version(session.tls_version(), maximum_version);
             blocking_write_all(&mut session, PAYLOAD);
             let mut echoed = [0; PAYLOAD.len()];
             blocking_read_exact(&mut session, &mut echoed);
@@ -475,6 +514,23 @@ fn async_construction_failure_leaves_borrowed_stream_usable() {
         drive_pair(client.connect(), server.connect(), handshake_wake);
     client_result.unwrap();
     server_result.unwrap();
+}
+
+/// The cap paths of the runners above otherwise only run under `ecp-restartable`,
+/// so pin the cap-to-negotiated-version mapping unconditionally on both flavours.
+#[test]
+fn loopback_negotiated_version_honours_the_client_cap() {
+    let _serial = SERIAL.lock().unwrap_or_else(|error| error.into_inner());
+    let mut rng = StdRng;
+    // SAFETY: `rng` is declared before `tls`, and every session and `tls` are
+    // dropped in this scope before the borrowed RNG can go out of scope.
+    let tls = unsafe { Tls::new_local_borrows(&mut rng) }.unwrap();
+
+    // `run_*_loopback` asserts the negotiated version against the cap it is given.
+    run_async_loopback(tls.reference(), Some(TlsVersion::Tls1_2));
+    run_async_loopback(tls.reference(), Some(TlsVersion::Tls1_3));
+    run_blocking_loopback(tls.reference(), Some(TlsVersion::Tls1_2), None);
+    run_blocking_loopback(tls.reference(), Some(TlsVersion::Tls1_3), None);
 }
 
 #[test]


### PR DESCRIPTION
The one thing remaining to close #167, and given how simple it is, why not?