### PR TITLE
Reconfigure CMake from scratch

### DIFF
--- a/mbedtls-rs-sys/CHANGELOG.md
+++ b/mbedtls-rs-sys/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Reconfigure CMake from scratch when the compiler changed since the last build, rather than letting CMake half-reset its own cache
 * Update MSRV to 1.85
 * (Breaking) Un-hooked digests and AES now fall back to MbedTLS's own software implementations rather than to RustCrypto
 * `MBEDTLS_AES_FEWER_TABLES` is now set: the software AES tables cost 2.5 KB of flash instead of 8.7 KB, so TLS images end up ~2 KB smaller than with the RustCrypto fallback

--- a/mbedtls-rs-sys/gen/builder.rs
+++ b/mbedtls-rs-sys/gen/builder.rs
@@ -736,6 +736,14 @@ impl MbedtlsBuilder {
 
         let target_dir = out_path.join("mbedtls").join("build");
         std::fs::create_dir_all(&target_dir)?;
+
+        // Configure from scratch. CMake cannot reuse a build tree whose compiler
+        // changed: it deletes the cache mid-configure and re-runs, and options
+        // the project set on the first pass do not reliably survive that reset.
+        // This build script re-runs only when `gen/` or the submodule changed
+        // (see `track`), so the ordinary Rust edit loop never pays for the
+        // rebuild. `cmake-rs` configures in `<out_dir>/build`.
+        let _ = std::fs::remove_dir_all(target_dir.join("build"));
         let target_include_dir = target_dir.join("include");
         std::fs::create_dir_all(&target_include_dir)?;
 


### PR DESCRIPTION
A one-liner fix backported from `openthread` where it was found when implementing compile support for GCC.